### PR TITLE
Fix issue on memory allocation in multiple inputs

### DIFF
--- a/android/src/main/java/com/azihsoyn/flutter/mlkit/MlkitPlugin.java
+++ b/android/src/main/java/com/azihsoyn/flutter/mlkit/MlkitPlugin.java
@@ -309,8 +309,8 @@ public class MlkitPlugin implements MethodCallHandler {
                 Map<String, List<Map<String, Object>>> inputOutputOptionsMap = call.argument("inputOutputOptions");
 
                 List<Map<String, Object>> inputOptions = inputOutputOptionsMap.get("inputOptions");
+                int offset = 0;
                 for (int i = 0; i < inputOptions.size(); i++) {
-
                     int inputDataType = (int) inputOptions.get(i).get("dataType");
                     ArrayList<Integer> _inputDims = (ArrayList<Integer>) inputOptions.get(i).get("dims");
                     ioBuilder.setInputFormat(i, inputDataType, toArray(_inputDims));
@@ -322,10 +322,12 @@ public class MlkitPlugin implements MethodCallHandler {
                     } else if (inputDataType == FirebaseModelDataType.LONG) {
                         bytesPerChannel = 8;
                     }
-                    ByteBuffer buffer = ByteBuffer.allocateDirect(toDim(_inputDims) * bytesPerChannel);
+                    int length = toDim(_inputDims) * bytesPerChannel;
+                    ByteBuffer buffer = ByteBuffer.allocateDirect(length);
                     buffer.order(ByteOrder.nativeOrder());
                     buffer.rewind();
-                    buffer.put(data);
+                    buffer.put(data, offset, length);
+                    offset += length;
                     inputsBuilder.add(buffer);
                 }
 


### PR DESCRIPTION
This PR fixes issues on multiple inputs for custom models.

The issues we want to improve occur as follows:

1. In the current signature of `FirebaseModelInterpreter.run()`, multiple inputs should be concatenated into a `Uint8List` and passed as `inputBytes`.
2. In `FirebaseModelInterpreter#run`, `ByteBuffer` is allocated for each input. Its capacity is the size of each input, not the sum of all inputs.
3. `inputBytes` is dispatched into `ByteBuffer`. Note that, the size of `inputBytes` is the sum of all inputs.
4. Buffer overflow is occurred since the capacity of allocated `ByteBuffer` is smaller than the size of `InputBytes`.

I tested fixed code using the following gist.
https://gist.github.com/arosh/c4bf342669b52a647b1f1a780f65aa6d