### PR TITLE
Add link to the new firebase_ml_custom plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![pub package](https://img.shields.io/pub/v/mlkit.svg)](https://pub.dartlang.org/packages/mlkit)
 
-A Flutter plugin to use the Firebase ML Kit.
+A Flutter plugin to use the Firebase ML.
 
 :star:*Only your star motivate me!*:star:
 
 ## this is *not official* package
-The flutter team now has the [firebase_ml_vision](https://pub.dartlang.org/packages/firebase_ml_vision) package for Firebase ML Kit. Please consider trying to use firebase_ml_vision. 
+The flutter team now has the [firebase_ml_vision](https://pub.dartlang.org/packages/firebase_ml_vision) and [firebase_ml_custom](https://pub.dev/packages/firebase_ml_custom) packages for Firebase ML. Please consider trying to use firebase_ml_vision for vision APIs and firebase_ml_custom for hosting custom models. 
 
 *Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/azihsoyn/flutter_mlkit/issues) and [Pull Requests](https://github.com/azihsoyn/flutter_mlkit/pulls) are most welcome!
 


### PR DESCRIPTION
Hi,

Our intern @PolinaGo recently developed a new `firebase_ml_custom` plugin for hosting custom model with the guidance of the Flutter and Firebase team. 

Is it ok if we add a link to this new plugin?

Also [recently Firebase ML Kit rebranded to Firebase ML](https://android-developers.googleblog.com/2020/06/mlkit-on-device-machine-learning-solutions.html), and now ML Kit is a standalone SDK independent from Firebase. So I updated couple places here as well.

Thank you!